### PR TITLE
Some initial changes to support VODF

### DIFF
--- a/fits_schema/binary_table.py
+++ b/fits_schema/binary_table.py
@@ -63,6 +63,7 @@ class Column(metaclass=ABCMeta):
         name=None,
         ndim=None,
         shape=None,
+        description: str="",
     ):
         self.required = required
         self.unit = unit
@@ -70,6 +71,7 @@ class Column(metaclass=ABCMeta):
         self.name = name
         self.shape = shape
         self.ndim = ndim
+        self.description = description
 
         if self.shape is not None:
             self.shape = tuple(shape)

--- a/fits_schema/binary_table.py
+++ b/fits_schema/binary_table.py
@@ -182,11 +182,27 @@ class BinaryTableMeta(type):
                 '`__header__` must be a class inheriting from `BinaryTableHeader`'
             )
 
+        # ensure we have a __header__ if not specified
+        if not header_schema:
+            dct['__header__'] = BinaryTableHeader()
+
+        # inherit header schema and  from bases
+        for base in reversed(bases):
+            if hasattr(base, '__header__'):
+                dct['__header__'].update(base.__header__)
+
+            if issubclass(base, BinaryTable):
+                dct['__columns__'].update(base.__columns__)
+
         # collect columns of this new schema
         for k, v in dct.items():
             if isinstance(v, Column):
                 k = v.name or k
                 dct['__columns__'][k] = v
+
+        if header_schema is not None:
+            # add user defined header last
+            dct['__header__'].update(header_schema)
 
         new_cls = super().__new__(cls, name, bases, dct)
         return new_cls

--- a/fits_schema/binary_table.py
+++ b/fits_schema/binary_table.py
@@ -176,28 +176,11 @@ class BinaryTableMeta(type):
         dct['__columns__'] = {}
         dct['__slots__'] = ('__data__', 'header')
 
-        header_schema = dct.pop('__header__', None)
-        if header_schema is not None and not issubclass(header_schema, HeaderSchema):
+        header_schema = dct.get('__header__', None)
+        if header_schema is not None and not issubclass(header_schema, BinaryTableHeader):
             raise TypeError(
-                '`__header__` must be a class inheriting from `HeaderSchema`'
+                '`__header__` must be a class inheriting from `BinaryTableHeader`'
             )
-
-        # create a new header schema class for this table
-        dct['__header__'] = HeaderSchemaMeta.__new__(
-            HeaderSchemaMeta, name + 'Header', (BinaryTableHeader, ), {},
-        )
-
-        # inherit header schema and  from bases
-        for base in reversed(bases):
-            if hasattr(base, '__header__'):
-                dct['__header__'].update(base.__header__)
-
-            if issubclass(base, BinaryTable):
-                dct['__columns__'].update(base.__columns__)
-
-        if header_schema is not None:
-            # add user defined header last
-            dct['__header__'].update(header_schema)
 
         # collect columns of this new schema
         for k, v in dct.items():

--- a/fits_schema/fits_standard.py
+++ b/fits_schema/fits_standard.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from .header import HeaderSchema, HeaderCard
+
+
+class FITSStandardHeaders(HeaderSchema):
+    """Optional Headers defined by the `FITS Standard v4.0
+    <https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf>`.
+    """
+
+    EXTEND = HeaderCard(type_=bool, required=False)
+    ORIGIN = HeaderCard(type_=str, required=False)
+    TELESCOP = HeaderCard(type_=str, required=False)
+    INSTRUME = HeaderCard(type_=str, required=False)
+    OBSERVER = HeaderCard(type_=str, required=False)
+    OBJECT = HeaderCard(type_=str, required=False)
+    AUTHOR = HeaderCard(type_=str, required=False)
+    REFERENC = HeaderCard(type_=str, required=False)
+    COMMENT = HeaderCard(type_=str, required=False)
+    HISTORY = HeaderCard(type_=str, required=False)
+    CREATOR = HeaderCard(type_=str, required=False)
+    PROGRAM = HeaderCard(type_=str, required=False)
+
+    # see table 22 of https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
+    DATE = HeaderCard(type_=str, required=False)
+    DATE_OBS = HeaderCard(keyword="DATE-OBS", type_=str, required=False)
+    DATE_BEG = HeaderCard(keyword="DATE-BEG", type_=str, required=False)
+    DATE_AVG = HeaderCard(keyword="DATE-AVG", type_=str, required=False)
+    DATE_END = HeaderCard(keyword="DATE-END", type_=str, required=False)
+
+    MJD_OBS = HeaderCard(keyword="MJD-OBS", type_=float, required=False)
+    MJD_BEG = HeaderCard(keyword="MJD-BEG", type_=float, required=False)
+    MJD_AVG = HeaderCard(keyword="MJD-AVG", type_=float, required=False)
+    MJD_END = HeaderCard(keyword="MJD-END", type_=float, required=False)
+
+    # time definition
+    MJDREF = HeaderCard(type_=float, required=False)
+    MJDREFI = HeaderCard(type_=int, required=False)
+    MJDREFF = HeaderCard(type_=float, required=False)
+    JDREF = HeaderCard(type_=float, required=False)
+    JDREFI = HeaderCard(type_=int, required=False)
+    JDREFF = HeaderCard(type_=float, required=False)
+    DATEREF = HeaderCard(type_=float, required=False)
+
+    # start / end time relative to reference time
+    TSTART = HeaderCard(type_=float, required=False)
+    TSTOP = HeaderCard(type_=float, required=False)

--- a/fits_schema/header.py
+++ b/fits_schema/header.py
@@ -194,8 +194,22 @@ class HeaderSchema(metaclass=HeaderSchemaMeta):
 
     @classmethod
     def _header_schemas(cls) -> list[Self]:
-        """returns a list of """
-        return [base for base in cls.__bases__ if issubclass(base, HeaderSchema)]
+        """returns a list of HeaderSchema parents"""
+        return list(reversed([cls,] + [base for base in cls.__bases__ if issubclass(base, HeaderSchema)]))
+
+    @classmethod
+    def grouped_cards(self) -> dict[Self,HeaderCard]:
+        """Return a list of cards grouped by parent HeaderSchema class"""
+        seen = []
+        group = {}
+
+        for schema in self._header_schemas():
+            group[schema] = {k: c for k,c in schema.__cards__.items() if k not in seen}
+            seen.extend(schema.__cards__.keys())
+
+        return group
+
+
 
     @classmethod
     def validate_header(cls, header: fits.Header, onerror='raise'):

--- a/fits_schema/header.py
+++ b/fits_schema/header.py
@@ -200,12 +200,12 @@ class HeaderSchema(metaclass=HeaderSchemaMeta):
     @classmethod
     def grouped_cards(self) -> dict[Self,HeaderCard]:
         """Return a list of cards grouped by parent HeaderSchema class"""
-        seen = []
+        seen = set()
         group = {}
 
         for schema in self._header_schemas():
             group[schema] = {k: c for k,c in schema.__cards__.items() if k not in seen}
-            seen.extend(schema.__cards__.keys())
+            seen.update(schema.__cards__.keys())
 
         return group
 

--- a/fits_schema/header.py
+++ b/fits_schema/header.py
@@ -50,7 +50,7 @@ class HeaderCard:
         match str values case insensitively
     '''
     def __init__(
-        self, keyword=None, *, required=True,
+        self, keyword=None, description: str = "", *,required=True,
         allowed_values=None, position=None, type_=None,
         empty=None, case_insensitive=True,
     ):
@@ -62,6 +62,7 @@ class HeaderCard:
         self.position = position
         self.empty = empty
         self.case_insensitive = case_insensitive
+        self.description = description
 
         vals = allowed_values
         if vals is not None:

--- a/fits_schema/header.py
+++ b/fits_schema/header.py
@@ -5,6 +5,7 @@ See section 4 of the FITS Standard:
 https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 '''
 from datetime import date, datetime
+from typing import Self
 from .exceptions import (
     RequiredMissing, WrongType, WrongPosition, AdditionalHeaderCard,
     WrongValue,
@@ -189,44 +190,11 @@ class HeaderSchema(metaclass=HeaderSchemaMeta):
     ...    class __header_schema__(HeaderSchema):
     ...        HDUCLASS = HeaderCard(required=True, allowed_values="Events")
     '''
-    # define some common header keywords
-    EXTEND   = HeaderCard(type_=bool, required=False)
-    ORIGIN   = HeaderCard(type_=str, required=False)
-    TELESCOP = HeaderCard(type_=str, required=False)
-    INSTRUME = HeaderCard(type_=str, required=False)
-    OBSERVER = HeaderCard(type_=str, required=False)
-    OBJECT   = HeaderCard(type_=str, required=False)
-    AUTHOR   = HeaderCard(type_=str, required=False)
-    REFERENC = HeaderCard(type_=str, required=False)
-    COMMENT  = HeaderCard(type_=str, required=False)
-    HISTORY  = HeaderCard(type_=str, required=False)
-    CREATOR  = HeaderCard(type_=str, required=False)
-    PROGRAM  = HeaderCard(type_=str, required=False)
 
-    # see table 22 of https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
-    DATE     = HeaderCard(type_=str, required=False)
-    DATE_OBS = HeaderCard(keyword='DATE-OBS', type_=str, required=False)
-    DATE_BEG = HeaderCard(keyword='DATE-BEG', type_=str, required=False)
-    DATE_AVG = HeaderCard(keyword='DATE-AVG', type_=str, required=False)
-    DATE_END = HeaderCard(keyword='DATE-END', type_=str, required=False)
-
-    MJD_OBS  = HeaderCard(keyword='MJD-OBS', type_=float, required=False)
-    MJD_BEG  = HeaderCard(keyword='MJD-BEG', type_=float, required=False)
-    MJD_AVG  = HeaderCard(keyword='MJD-AVG', type_=float, required=False)
-    MJD_END  = HeaderCard(keyword='MJD-END', type_=float, required=False)
-
-    # time definition
-    MJDREF   = HeaderCard(type_=float, required=False)
-    MJDREFI  = HeaderCard(type_=int, required=False)
-    MJDREFF  = HeaderCard(type_=float, required=False)
-    JDREF    = HeaderCard(type_=float, required=False)
-    JDREFI   = HeaderCard(type_=int, required=False)
-    JDREFF   = HeaderCard(type_=float, required=False)
-    DATEREF  = HeaderCard(type_=float, required=False)
-
-    # start / end time relative to reference time
-    TSTART   = HeaderCard(type_=float, required=False)
-    TSTOP    = HeaderCard(type_=float, required=False)
+    @classmethod
+    def _header_schemas(cls) -> list[Self]:
+        """returns a list of """
+        return [base for base in cls.__bases__ if issubclass(base, HeaderSchema)]
 
     @classmethod
     def validate_header(cls, header: fits.Header, onerror='raise'):

--- a/tests/test_binary_table.py
+++ b/tests/test_binary_table.py
@@ -265,13 +265,13 @@ def test_header_not_schema():
 
 
 def test_header():
-    from fits_schema.binary_table import BinaryTable, Double
-    from fits_schema.header import HeaderSchema, HeaderCard
+    from fits_schema.binary_table import BinaryTable, BinaryTableHeader, Double
+    from fits_schema.header import HeaderCard
 
     class TestTable(BinaryTable):
         energy = Double(unit=u.TeV)
 
-        class __header__(HeaderSchema):
+        class __header__(BinaryTableHeader):
             TEST = HeaderCard(type_=str)
 
     t = Table({'energy': [1, 2, 3] * u.TeV})

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -8,11 +8,11 @@ from astropy.io import fits
 def test_length():
     from fits_schema.header import HeaderCard, HeaderSchema
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         class LengthHeader(HeaderSchema):
             MORE_THAN_8 = HeaderCard()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         class LowerHeader(HeaderSchema):
             lowercas = HeaderCard()
 


### PR DESCRIPTION
## Breaking changes:

* simplified `__header__` header class creation. 
   * No longer generates a new class, which allows the subclass to retain its bases
   * Requires that  `__header__`  internal classes of `BinaryTable` subclasses inherit from `BinTableHeader` instead of `HeaderSchema
   * Removed the standard FITS header definitions from the base `HeaderSchema` and moved them into their own class. That prevents them from appearing in the docs, and they can still be used in a validator.  For defining VODF, we don't want that all these are allowed in a VODF file, but rather that if we define similar headers, the schema should be checked against these so we can be sure the *schema* doesn't violate FITS standards. Therefore they are not *part* of all schemas, but rather can be used to validate schemas.

## New features:

* Headers can be retrieved in a form grouped by their parent classes, so that in documentation, they appear together and with group info generated from the class docstring. The `__cards__` API is unchanged, for when they are needed as a merged list:
```python
HeaderSchemaSubclass.grouped_cards() → dict[HeaderSchema, list[HeaderCard]]
```
* started to add some extra metadata for documentation, e.g. `description` field for `HeaderCards` and `Columns`